### PR TITLE
Support image push, in-app expiry, and push action buttons

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -21,6 +21,7 @@ interface PushNotification {
         [key: string]: any;
     } | null;
     url?: string | null;
+    actionId?: string;
 }
 
 interface PushChannelManager {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-kumulos-sdk",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cordova-plugin-kumulos-sdk",
-    "version": "4.0.1",
+    "version": "4.1.0",
     "types": "./index.d.ts",
     "description": "Official Cordova SDK for integrating Kumulos services with your mobile apps",
     "cordova": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -60,6 +60,7 @@
                 <intent-filter>
                     <action android:name="com.kumulos.push.RECEIVED" />
                     <action android:name="com.kumulos.push.OPENED" />
+                    <action android:name="com.kumulos.push.BUTTON_CLICKED" />
                 </intent-filter>
             </receiver>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<plugin id="cordova-plugin-kumulos-sdk" version="4.0.1" 
-    xmlns="http://apache.org/cordova/ns/plugins/1.0" 
+<plugin id="cordova-plugin-kumulos-sdk" version="4.1.0"
+    xmlns="http://apache.org/cordova/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android">
     <name>KumulosSDKPlugin</name>
     <asset src="www/vendors~raven-js.bundle.js" target="plugins/cordova-plugin-kumulos-sdk/www/vendors~raven-js.bundle.js" />

--- a/src/android/KumulosInitProvider.java
+++ b/src/android/KumulosInitProvider.java
@@ -66,6 +66,8 @@ public class KumulosInitProvider extends ContentProvider {
             KumulosInApp.setDeepLinkHandler(new KumulosSDKPlugin.InAppDeepLinkHandler());
         }
 
+        Kumulos.setPushActionHandler(new PushReceiver.PushActionHandler());
+
         JSONObject runtimeInfo = new JSONObject();
         JSONObject sdkInfo = new JSONObject();
 

--- a/src/android/KumulosInitProvider.java
+++ b/src/android/KumulosInitProvider.java
@@ -20,7 +20,7 @@ import org.json.JSONObject;
 
 public class KumulosInitProvider extends ContentProvider {
 
-    private static final String SDK_VERSION = "4.0.1";
+    private static final String SDK_VERSION = "4.1.0";
     private static final int RUNTIME_TYPE = 3;
     private static final int SDK_TYPE = 6;
 

--- a/src/android/KumulosSDKPlugin.java
+++ b/src/android/KumulosSDKPlugin.java
@@ -113,7 +113,6 @@ public class KumulosSDKPlugin extends CordovaPlugin {
             message.put("data", data);
         }  catch (JSONException e) {
             e.printStackTrace();
-
             return false;
         }
 

--- a/src/android/KumulosSDKPlugin.java
+++ b/src/android/KumulosSDKPlugin.java
@@ -33,6 +33,8 @@ public class KumulosSDKPlugin extends CordovaPlugin {
     static CallbackContext jsCallbackContext;
     @Nullable
     static PushMessage pendingPush;
+    @Nullable
+    static String pendingActionId;
 
     static CordovaInterface sCordova;
 
@@ -111,6 +113,7 @@ public class KumulosSDKPlugin extends CordovaPlugin {
             message.put("data", data);
         }  catch (JSONException e) {
             e.printStackTrace();
+
             return false;
         }
 
@@ -203,8 +206,9 @@ public class KumulosSDKPlugin extends CordovaPlugin {
         callbackContext.sendPluginResult(result);
 
         if (null != pendingPush) {
-            KumulosSDKPlugin.sendMessageToJs("pushOpened", PushReceiver.pushMessageToJsonObject(pendingPush));
+            KumulosSDKPlugin.sendMessageToJs("pushOpened", PushReceiver.pushMessageToJsonObject(pendingPush, pendingActionId));
             pendingPush = null;
+            pendingActionId = null;
         }
     }
 

--- a/src/android/PushReceiver.java
+++ b/src/android/PushReceiver.java
@@ -31,6 +31,11 @@ public class PushReceiver extends PushBroadcastReceiver {
                  message.put("actionId", actionId);
             }
 
+            String pictureUrl = pushMessage.getPictureUrl();
+            if (pictureUrl != null){
+                message.put("pictureUrl", pictureUrl);
+            }
+
             message.put("data", pushMessage.getData());
         } catch (JSONException e) {
             e.printStackTrace();

--- a/src/android/PushReceiver.java
+++ b/src/android/PushReceiver.java
@@ -31,11 +31,6 @@ public class PushReceiver extends PushBroadcastReceiver {
                  message.put("actionId", actionId);
             }
 
-            String pictureUrl = pushMessage.getPictureUrl();
-            if (pictureUrl != null){
-                message.put("pictureUrl", pictureUrl);
-            }
-
             message.put("data", pushMessage.getData());
         } catch (JSONException e) {
             e.printStackTrace();

--- a/src/android/PushReceiver.java
+++ b/src/android/PushReceiver.java
@@ -110,6 +110,9 @@ public class PushReceiver extends PushBroadcastReceiver {
         @Override
         public void handle(Context context, PushMessage pushMessage, String actionId) {
             PushReceiver.handlePushOpen(context, pushMessage, actionId);
+
+            Intent it = new Intent(Intent.ACTION_CLOSE_SYSTEM_DIALOGS);
+            context.sendBroadcast(it);
         }
     }
 }

--- a/src/android/kumulos.gradle
+++ b/src/android/kumulos.gradle
@@ -15,8 +15,8 @@ android {
 }
 
 dependencies {
-    debugImplementation 'com.kumulos.android:kumulos-android-debug:8.1.0'
-    releaseImplementation 'com.kumulos.android:kumulos-android-release:8.1.0'
+    debugImplementation 'com.kumulos.android:kumulos-android-debug:8.4.1'
+    releaseImplementation 'com.kumulos.android:kumulos-android-release:8.4.1'
     implementation 'com.google.firebase:firebase-core:16.0.7'
 }
 

--- a/src/ios/KumulosSDKPlugin.m
+++ b/src/ios/KumulosSDKPlugin.m
@@ -5,7 +5,7 @@
 #import <KumulosSDK/KumulosSDK.h>
 @import CoreLocation;
 
-static const NSString* KSCordovaSdkVersion = @"4.0.1";
+static const NSString* KSCordovaSdkVersion = @"4.1.0";
 static IMP KSexistingAppDidLaunchDelegate = NULL;
 
 static CDVInvokedUrlCommand* KSjsCordovaCommand = nil;


### PR DESCRIPTION
### Description of Changes

Support for
1. message expiry
2. push images
3. push action buttons

For that update ObjSdk dependency, pass actionId through to JS

### Breaking Changes

-   None

### Release Checklist

Prepare:

-   [x] Detail any breaking changes. Breaking changes require a new major version number

Bump versions in:

-   [x] package.json
-   [x] plugin.xml
-   [x] src/ios/KumulosSDKPlugin.m
-   [x] src/android/.../KumulosInitProvider.java

Release:

-   [ ] Squash and merge to master
-   [ ] Delete branch once merged
-   [ ] Create tag from master matching chosen version
-   [ ] Fill out release notes
-   [ ] Run `npm publish`
