### PR TITLE
Bugfix: opening push with url does nothing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-kumulos-sdk",
-  "version": "4.2.3",
+  "version": "4.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cordova-plugin-kumulos-sdk",
-    "version": "4.2.3",
+    "version": "4.2.4",
     "types": "./index.d.ts",
     "description": "Official Cordova SDK for integrating Kumulos services with your mobile apps",
     "cordova": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<plugin id="cordova-plugin-kumulos-sdk" version="4.2.3"
+<plugin id="cordova-plugin-kumulos-sdk" version="4.2.4"
     xmlns="http://apache.org/cordova/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android">
     <name>KumulosSDKPlugin</name>

--- a/src/android/KumulosInitProvider.java
+++ b/src/android/KumulosInitProvider.java
@@ -20,7 +20,7 @@ import org.json.JSONObject;
 
 public class KumulosInitProvider extends ContentProvider {
 
-    private static final String SDK_VERSION = "4.2.3";
+    private static final String SDK_VERSION = "4.2.4";
     private static final int RUNTIME_TYPE = 3;
     private static final int SDK_TYPE = 6;
 

--- a/src/android/PushReceiver.java
+++ b/src/android/PushReceiver.java
@@ -4,6 +4,7 @@ import android.app.Activity;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
+import android.app.TaskStackBuilder;
 
 import com.kumulos.android.Kumulos;
 import com.kumulos.android.PushBroadcastReceiver;
@@ -83,19 +84,28 @@ public class PushReceiver extends PushBroadcastReceiver {
             return;
         }
 
-        if (null != pushMessage.getUrl()) {
-            launchIntent = new Intent(Intent.ACTION_VIEW, pushMessage.getUrl());
-        }
-
-        launchIntent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
-        addDeepLinkExtras(pushMessage, launchIntent);
-
         if (KumulosSDKPlugin.sCordova != null){
             Intent existingIntent = KumulosSDKPlugin.sCordova.getActivity().getIntent();
             addDeepLinkExtras(pushMessage, existingIntent);
         }
 
-        context.startActivity(launchIntent);
+        if (null != pushMessage.getUrl()) {
+            launchIntent = new Intent(Intent.ACTION_VIEW, pushMessage.getUrl());
+
+            addDeepLinkExtras(pushMessage, launchIntent);
+
+            TaskStackBuilder taskStackBuilder = TaskStackBuilder.create(context);
+            taskStackBuilder.addParentStack(component);
+            taskStackBuilder.addNextIntent(launchIntent);
+            taskStackBuilder.startActivities();
+        }
+        else{
+            launchIntent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
+
+            addDeepLinkExtras(pushMessage, launchIntent);
+
+            context.startActivity(launchIntent);
+        }
 
         if (null == KumulosSDKPlugin.jsCallbackContext) {
             KumulosSDKPlugin.pendingPush = pushMessage;

--- a/src/ios/KumulosSDKPlugin.m
+++ b/src/ios/KumulosSDKPlugin.m
@@ -4,7 +4,7 @@
 #import <KumulosSDK/KumulosSDK.h>
 @import CoreLocation;
 
-static const NSString* KSCordovaSdkVersion = @"4.2.3";
+static const NSString* KSCordovaSdkVersion = @"4.2.4";
 
 static CDVInvokedUrlCommand* KSjsCordovaCommand = nil;
 static KSPushNotification* KSpendingPush = nil;


### PR DESCRIPTION
### Description of Changes

Similar to the issue in RN. If push has url we launch ACTION_VIEW intent with flag SINGLE_TOP, but there is no existing activity

Like in AndroidSDK/RN current implementation does not launch app if url push open.

### Breaking Changes

-   None

### Release Checklist

Prepare:

-   [ ] ~~`npm run dist` to produce minified artifacts~~
-   [ ] ~~Detail any breaking changes. Breaking changes require a new major version number~~
-   [ ] ~~Update type declarations in index.d.ts~~

Bump versions in:

-   [x] package.json
-   [x] plugin.xml
-   [x] src/ios/KumulosSDKPlugin.m
-   [x] src/android/.../KumulosInitProvider.java

Release:

-   [ ] Squash and merge to master
-   [ ] Delete branch once merged
-   [ ] Create tag from master matching chosen version
-   [ ] Fill out release notes
-   [ ] Run `npm publish`
