### PR TITLE
Android Channel Support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cordova-plugin-kumulos-sdk",
-    "version": "5.0.0",
+    "version": "5.1.0",
     "types": "./index.d.ts",
     "description": "Official Cordova SDK for integrating Kumulos services with your mobile apps",
     "cordova": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<plugin id="cordova-plugin-kumulos-sdk" version="5.0.0"
+<plugin id="cordova-plugin-kumulos-sdk" version="5.1.0"
     xmlns="http://apache.org/cordova/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android">
     <name>KumulosSDKPlugin</name>

--- a/src/android/KumulosInitProvider.java
+++ b/src/android/KumulosInitProvider.java
@@ -20,7 +20,7 @@ import org.json.JSONObject;
 
 public class KumulosInitProvider extends ContentProvider {
 
-    private static final String SDK_VERSION = "5.0.0";
+    private static final String SDK_VERSION = "5.1.0";
     private static final int RUNTIME_TYPE = 3;
     private static final int SDK_TYPE = 6;
 

--- a/src/android/kumulos.gradle
+++ b/src/android/kumulos.gradle
@@ -15,8 +15,8 @@ android {
 }
 
 dependencies {
-    debugImplementation 'com.kumulos.android:kumulos-android-debug:12.0.0'
-    releaseImplementation 'com.kumulos.android:kumulos-android-release:12.0.0'
+    debugImplementation 'com.kumulos.android:kumulos-android-debug:12.1.0'
+    releaseImplementation 'com.kumulos.android:kumulos-android-release:12.1.0'
 }
 
 // Application of google services plugin based on

--- a/src/ios/KumulosSDKPlugin.m
+++ b/src/ios/KumulosSDKPlugin.m
@@ -4,7 +4,7 @@
 #import <KumulosSDK/KumulosSDK.h>
 @import CoreLocation;
 
-static const NSString* KSCordovaSdkVersion = @"5.0.0";
+static const NSString* KSCordovaSdkVersion = @"5.1.0";
 
 static CDVInvokedUrlCommand* KSjsCordovaCommand = nil;
 static KSPushNotification* KSpendingPush = nil;


### PR DESCRIPTION
### Description of Changes

The Kumulos push API now supports the mutually exclusive keys for android notifications

- notificationType: Hint to the SDK whether a notification should default to the tray or a banner (priority default or max respectively), this is automatic and handled between the Kumulos push pipeline and the SDK.

- notificationChannel: If the app developer has setup specific channels for content then setting this key will forward it to the end consumer and is readable on the PushMessage object.

### Breaking Changes

-   None

### Release Checklist

Prepare:

-   [x] `npm run dist` to produce minified artifacts
-   [x] Detail any breaking changes. Breaking changes require a new major version number
-   [x] Update type declarations in index.d.ts

Bump versions in:

-   [x] package.json
-   [x] plugin.xml
-   [x] src/ios/KumulosSDKPlugin.m
-   [x] src/android/.../KumulosInitProvider.java

Release:

-   [ ] Squash and merge to master
-   [ ] Delete branch once merged
-   [ ] Create tag from master matching chosen version
-   [ ] Fill out release notes
-   [ ] Run `npm publish`
